### PR TITLE
Fix/remove dead contact links

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
   "author": "Hack & Söhne",
   "license": "ISC",
   "homepage": "https://hackundsoehne.de",
-  "dependencies": {},
   "devDependencies": {
     "http-server": "^0.9.0"
   },

--- a/src/404.html
+++ b/src/404.html
@@ -154,7 +154,6 @@
                                         <li><a href="https://www.facebook.com/hackundsoehne/" target="_blank"><i class="fa fa-facebook"></i></a></li>
                                         <li><a href="https://twitter.com/hackundsoehne" target="_blank"><i class="fa fa-twitter"></i></a></li>
                                         <li><a href="https://github.com/hackundsoehne" target="_blank"><i class = "fa fa-github"></i></a></li>
-                                        <!--<li><a href="https://slack.hackundsoehne.de/" target="_blank"><i class="fa fa-slack"></i></a></li>-->
                                         <li><a href="https://www.instagram.com/hackundsoehne/" target="_blank"><i class="fa fa-instagram"></i></a></li>
                                         <li><a href="https://www.linkedin.com/company/hack-&-s%C3%B6hne/" target="_blank"><i class="fa fa-linkedin"></i></a></li>
                                     </ul>

--- a/src/androidBootcamp.html
+++ b/src/androidBootcamp.html
@@ -174,7 +174,6 @@
                                         <li><a href="https://www.facebook.com/hackundsoehne/" target="_blank"><i class="fa fa-facebook"></i></a></li>
                                         <li><a href="https://twitter.com/hackundsoehne" target="_blank"><i class="fa fa-twitter"></i></a></li>
                                         <li><a href="https://github.com/hackundsoehne" target="_blank"><i class = "fa fa-github"></i></a></li>
-                                        <li><a href="https://slack.hackundsoehne.de/" target="_blank"><i class="fa fa-slack"></i></a></li>
                                         <li><a href="https://www.instagram.com/hackundsoehne/" target="_blank"><i class="fa fa-instagram"></i></a></li>
                                         <li><a href="https://www.linkedin.com/company/hack-&-s%C3%B6hne/" target="_blank"><i class="fa fa-linkedin"></i></a></li>
                                     </ul>

--- a/src/basement.html
+++ b/src/basement.html
@@ -170,7 +170,6 @@
                                         <li><a href="https://www.facebook.com/hackundsoehne/" target="_blank"><i class="fa fa-facebook"></i></a></li>
                                         <li><a href="https://twitter.com/hackundsoehne" target="_blank"><i class="fa fa-twitter"></i></a></li>
                                         <li><a href="https://github.com/hackundsoehne" target="_blank"><i class = "fa fa-github"></i></a></li>
-                                        <!--<li><a href="https://slack.hackundsoehne.de/" target="_blank"><i class="fa fa-slack"></i></a></li>-->
                                         <li><a href="https://www.instagram.com/hackundsoehne/" target="_blank"><i class="fa fa-instagram"></i></a></li>
                                         <li><a href="https://www.linkedin.com/company/hack-&-s%C3%B6hne/" target="_blank"><i class="fa fa-linkedin"></i></a></li>
                                     </ul>

--- a/src/contact.html
+++ b/src/contact.html
@@ -134,9 +134,6 @@
                         <div class="col-md-12">
                             <div class="area-heading area-heading-style-two text-center">
                                 <h2 class="area-title" tkey="contact_title"></h2>
-                                <p style="font-size: 1.75rem"><a href="javascript:Smooch.open()" tkey="quest_report_ask"></a><i tkey="quest_report_send"></i>
-                                    <a href="mailto:info@hackundsoehne.de" tkey="quest_report_mail"></a><!--<i tkey="quest_report_join"></i><a
-                                            href="https://slack.hackundsoehne.de" target="_blank">Slack</a><i tkey="quest_report_join_2"></i>--></p>
                             </div>
                         </div>
                     </div>
@@ -190,8 +187,6 @@
                                                 class="fa fa-twitter"></i></a></li>
                                         <li><a href="https://github.com/hackundsoehne" target="_blank"><i
                                                 class="fa fa-github"></i></a></li>
-                                        <!--<li><a href="https://slack.hackundsoehne.de/" target="_blank"><i
-                                                class="fa fa-slack"></i></a></li>-->
                                         <li><a href="https://www.instagram.com/hackundsoehne/" target="_blank"><i
                                                 class="fa fa-instagram"></i></a></li>
                                         <li><a href="https://www.linkedin.com/company/hack-&-s%C3%B6hne/"

--- a/src/dataprivacy.html
+++ b/src/dataprivacy.html
@@ -238,7 +238,6 @@
                                             <li><a href="https://www.facebook.com/hackundsoehne/" target="_blank"><i class="fa fa-facebook"></i></a></li>
                                             <li><a href="https://twitter.com/hackundsoehne" target="_blank"><i class="fa fa-twitter"></i></a></li>
                                             <li><a href="https://github.com/hackundsoehne" target="_blank"><i class = "fa fa-github"></i></a></li>
-                                            <!--<li><a href="https://slack.hackundsoehne.de/" target="_blank"><i class="fa fa-slack"></i></a></li>-->
                                             <li><a href="https://www.instagram.com/hackundsoehne/" target="_blank"><i class="fa fa-instagram"></i></a></li>
                                             <li><a href="https://www.linkedin.com/company/hack-&-söhne/" target="_blank"><i class="fa fa-linkedin"></i></a></li>
                                         </ul>

--- a/src/deeplearning.html
+++ b/src/deeplearning.html
@@ -178,7 +178,6 @@
                                         <li><a href="https://www.facebook.com/hackundsoehne/" target="_blank"><i class="fa fa-facebook"></i></a></li>
                                         <li><a href="https://twitter.com/hackundsoehne" target="_blank"><i class="fa fa-twitter"></i></a></li>
                                         <li><a href="https://github.com/hackundsoehne" target="_blank"><i class = "fa fa-github"></i></a></li>
-                                        <!--<li><a href="https://slack.hackundsoehne.de/" target="_blank"><i class="fa fa-slack"></i></a></li>-->
                                         <li><a href="https://www.instagram.com/hackundsoehne/" target="_blank"><i class="fa fa-instagram"></i></a></li>
                                         <li><a href="https://www.linkedin.com/company/hack-&-s%C3%B6hne/" target="_blank"><i class="fa fa-linkedin"></i></a></li>
                                     </ul>

--- a/src/dexterity.html
+++ b/src/dexterity.html
@@ -181,7 +181,6 @@
                                         <li><a href="https://www.facebook.com/hackundsoehne/" target="_blank"><i class="fa fa-facebook"></i></a></li>
                                         <li><a href="https://twitter.com/hackundsoehne" target="_blank"><i class="fa fa-twitter"></i></a></li>
                                         <li><a href="https://github.com/hackundsoehne" target="_blank"><i class = "fa fa-github"></i></a></li>
-                                        <!--<li><a href="https://slack.hackundsoehne.de/" target="_blank"><i class="fa fa-slack"></i></a></li>-->
                                         <li><a href="https://www.instagram.com/hackundsoehne/" target="_blank"><i class="fa fa-instagram"></i></a></li>
                                         <li><a href="https://www.linkedin.com/company/hack-&-s%C3%B6hne/" target="_blank"><i class="fa fa-linkedin"></i></a></li>
                                     </ul>

--- a/src/events.html
+++ b/src/events.html
@@ -495,7 +495,6 @@
                                     <li><a href="https://www.facebook.com/hackundsoehne/" target="_blank"><i class="fa fa-facebook"></i></a></li>
                                     <li><a href="https://twitter.com/hackundsoehne" target="_blank"><i class="fa fa-twitter"></i></a></li>
                                     <li><a href="https://github.com/hackundsoehne" target="_blank"><i class = "fa fa-github"></i></a></li>
-                                    <!--<li><a href="https://slack.hackundsoehne.de/" target="_blank"><i class="fa fa-slack"></i></a></li>-->
                                     <li><a href="https://www.instagram.com/hackundsoehne/" target="_blank"><i class="fa fa-instagram"></i></a></li>
                                     <li><a href="https://www.linkedin.com/company/hack-&-s%C3%B6hne/" target="_blank"><i class="fa fa-linkedin"></i></a></li>
                                 </ul>

--- a/src/hacksuchtsoehne.html
+++ b/src/hacksuchtsoehne.html
@@ -174,7 +174,6 @@
                                         <li><a href="https://www.facebook.com/hackundsoehne/" target="_blank"><i class="fa fa-facebook"></i></a></li>
                                         <li><a href="https://twitter.com/hackundsoehne" target="_blank"><i class="fa fa-twitter"></i></a></li>
                                         <li><a href="https://github.com/hackundsoehne" target="_blank"><i class = "fa fa-github"></i></a></li>
-                                        <!--<li><a href="https://slack.hackundsoehne.de/" target="_blank"><i class="fa fa-slack"></i></a></li>-->
                                         <li><a href="https://www.instagram.com/hackundsoehne/" target="_blank"><i class="fa fa-instagram"></i></a></li>
                                         <li><a href="https://www.linkedin.com/company/hack-&-s%C3%B6hne/" target="_blank"><i class="fa fa-linkedin"></i></a></li>
                                     </ul>

--- a/src/hacksuchtsoehne_ss.html
+++ b/src/hacksuchtsoehne_ss.html
@@ -174,7 +174,6 @@
                                         <li><a href="https://www.facebook.com/hackundsoehne/" target="_blank"><i class="fa fa-facebook"></i></a></li>
                                         <li><a href="https://twitter.com/hackundsoehne" target="_blank"><i class="fa fa-twitter"></i></a></li>
                                         <li><a href="https://github.com/hackundsoehne" target="_blank"><i class = "fa fa-github"></i></a></li>
-                                        <!--<li><a href="https://slack.hackundsoehne.de/" target="_blank"><i class="fa fa-slack"></i></a></li>-->
                                         <li><a href="https://www.instagram.com/hackundsoehne/" target="_blank"><i class="fa fa-instagram"></i></a></li>
                                         <li><a href="https://www.linkedin.com/company/hack-&-s%C3%B6hne/" target="_blank"><i class="fa fa-linkedin"></i></a></li>
                                     </ul>

--- a/src/hacktival.html
+++ b/src/hacktival.html
@@ -178,8 +178,6 @@
                                                 class="fa fa-twitter"></i></a></li>
                                         <li><a href="https://github.com/hackundsoehne" target="_blank"><i
                                                 class="fa fa-github"></i></a></li>
-                                        <!--<li><a href="https://slack.hackundsoehne.de/" target="_blank"><i
-                                                class="fa fa-slack"></i></a></li>-->
                                         <li><a href="https://www.instagram.com/hackundsoehne/" target="_blank"><i
                                                 class="fa fa-instagram"></i></a></li>
                                         <li><a href="https://www.linkedin.com/company/hack-&-s%C3%B6hne/"

--- a/src/index.html
+++ b/src/index.html
@@ -208,8 +208,6 @@
                                                 class="fa fa-twitter"></i></a></li>
                                         <li><a href="https://github.com/hackundsoehne" target="_blank"><i
                                                 class="fa fa-github"></i></a></li>
-                                        <!--<li><a href="https://slack.hackundsoehne.de/" target="_blank"><i
-                                                class="fa fa-slack"></i></a></li>-->
                                         <li><a href="https://www.instagram.com/hackundsoehne/" target="_blank"><i
                                                 class="fa fa-instagram"></i></a></li>
                                         <li><a href="https://www.linkedin.com/company/hack-&-s%C3%B6hne/"
@@ -393,9 +391,7 @@
                         <div class="col-md-12">
                             <div class="area-heading area-heading-style-two text-center">
                                 <h2 class="area-title" tkey="quest_title"></h2>
-                                <p style="font-size: 1.75rem"><a href="javascript:Smooch.open()" tkey="quest_report_ask"></a><i tkey="quest_report_send"></i>
-                                    <a href="mailto:info@hackundsoehne.de" tkey="quest_report_mail"></a><!--<i tkey="quest_report_join"></i><a
-                                            href="https://slack.hackundsoehne.de" target="_blank">Slack</a><i tkey="quest_report_join_2"></i>--></p>
+                                <p style="font-size: 1.75rem"><i tkey="quest_report_send"></i> <a href="mailto:info@hackundsoehne.de" tkey="quest_report_mail"></a></p>
                             </div>
                         </div>
                     </div>
@@ -500,11 +496,9 @@
                                                 class="fa fa-twitter"></i></a></li>
                                         <li><a href="https://github.com/hackundsoehne" target="_blank"><i
                                                 class="fa fa-github"></i></a></li>
-                                        <!--<li><a href="https://slack.hackundsoehne.de/" target="_blank"><i
-                                                class="fa fa-slack"></i></a></li>-->
                                         <li><a href="https://www.instagram.com/hackundsoehne/" target="_blank"><i
                                                 class="fa fa-instagram"></i></a></li>
-                                        <li><a href="https://www.linkedin.com/company-beta/11070411"
+                                        <li><a href="https://www.linkedin.com/company/hack-&-s%C3%B6hne/"
                                                target="_blank"><i class="fa fa-linkedin"></i></a></li>
                                     </ul>
                                 </div>

--- a/src/java9.html
+++ b/src/java9.html
@@ -184,7 +184,6 @@
                                         <li><a href="https://www.facebook.com/hackundsoehne/" target="_blank"><i class="fa fa-facebook"></i></a></li>
                                         <li><a href="https://twitter.com/hackundsoehne" target="_blank"><i class="fa fa-twitter"></i></a></li>
                                         <li><a href="https://github.com/hackundsoehne" target="_blank"><i class = "fa fa-github"></i></a></li>
-                                        <!--<li><a href="https://slack.hackundsoehne.de/" target="_blank"><i class="fa fa-slack"></i></a></li>-->
                                         <li><a href="https://www.instagram.com/hackundsoehne/" target="_blank"><i class="fa fa-instagram"></i></a></li>
                                         <li><a href="https://www.linkedin.com/company/hack-&-s%C3%B6hne/" target="_blank"><i class="fa fa-linkedin"></i></a></li>
                                     </ul>

--- a/src/lang/de.json
+++ b/src/lang/de.json
@@ -49,7 +49,7 @@
 
   "quest_title": "Noch Fragen?",
   "quest_report_ask": "Schreib uns ",
-  "quest_report_send": "· Sende uns eine",
+  "quest_report_send": "Sende uns eine",
   "quest_report_mail": "E-Mail ",
   "quest_report_join": "· Tritt unserem ",
   "quest_report_join_2": " bei",

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -49,7 +49,7 @@
 
   "quest_title": "Any questions?",
   "quest_report_ask": "Ask us ",
-  "quest_report_send": "· Send us an",
+  "quest_report_send": "Send us an",
   "quest_report_mail": "e-mail ",
   "quest_report_join": "· Join our ",
   "quest_report_join_2": "",

--- a/src/opencodes.html
+++ b/src/opencodes.html
@@ -168,7 +168,6 @@
                                         <li><a href="https://www.facebook.com/hackundsoehne/" target="_blank"><i class="fa fa-facebook"></i></a></li>
                                         <li><a href="https://twitter.com/hackundsoehne" target="_blank"><i class="fa fa-twitter"></i></a></li>
                                         <li><a href="https://github.com/hackundsoehne" target="_blank"><i class = "fa fa-github"></i></a></li>
-                                        <!--<li><a href="https://slack.hackundsoehne.de/" target="_blank"><i class="fa fa-slack"></i></a></li>-->
                                         <li><a href="https://www.instagram.com/hackundsoehne/" target="_blank"><i class="fa fa-instagram"></i></a></li>
                                         <li><a href="https://www.linkedin.com/company/hack-&-s%C3%B6hne/" target="_blank"><i class="fa fa-linkedin"></i></a></li>
                                     </ul>

--- a/src/oxygen.html
+++ b/src/oxygen.html
@@ -245,7 +245,6 @@
                                         <li><a href="https://www.facebook.com/hackundsoehne/" target="_blank"><i class="fa fa-facebook"></i></a></li>
                                         <li><a href="https://twitter.com/hackundsoehne" target="_blank"><i class="fa fa-twitter"></i></a></li>
                                         <li><a href="https://github.com/hackundsoehne" target="_blank"><i class = "fa fa-github"></i></a></li>
-                                        <!--<li><a href="https://slack.hackundsoehne.de/" target="_blank"><i class="fa fa-slack"></i></a></li>-->
                                         <li><a href="https://www.instagram.com/hackundsoehne/" target="_blank"><i class="fa fa-instagram"></i></a></li>
                                         <li><a href="https://www.linkedin.com/company/hack-&-s%C3%B6hne/" target="_blank"><i class="fa fa-linkedin"></i></a></li>
                                     </ul>

--- a/src/pitchWorkshop.html
+++ b/src/pitchWorkshop.html
@@ -170,7 +170,6 @@
                                         <li><a href="https://www.facebook.com/hackundsoehne/" target="_blank"><i class="fa fa-facebook"></i></a></li>
                                         <li><a href="https://twitter.com/hackundsoehne" target="_blank"><i class="fa fa-twitter"></i></a></li>
                                         <li><a href="https://github.com/hackundsoehne" target="_blank"><i class = "fa fa-github"></i></a></li>
-                                        <li><a href="https://slack.hackundsoehne.de/" target="_blank"><i class="fa fa-slack"></i></a></li>
                                         <li><a href="https://www.instagram.com/hackundsoehne/" target="_blank"><i class="fa fa-instagram"></i></a></li>
                                         <li><a href="https://www.linkedin.com/company/hack-&-s%C3%B6hne/" target="_blank"><i class="fa fa-linkedin"></i></a></li>
                                     </ul>

--- a/src/samsungopensource.html
+++ b/src/samsungopensource.html
@@ -228,7 +228,6 @@
                                         <li><a href="https://www.facebook.com/hackundsoehne/" target="_blank"><i class="fa fa-facebook"></i></a></li>
                                         <li><a href="https://twitter.com/hackundsoehne" target="_blank"><i class="fa fa-twitter"></i></a></li>
                                         <li><a href="https://github.com/hackundsoehne" target="_blank"><i class = "fa fa-github"></i></a></li>
-                                        <!--<li><a href="https://slack.hackundsoehne.de/" target="_blank"><i class="fa fa-slack"></i></a></li>-->
                                         <li><a href="https://www.instagram.com/hackundsoehne/" target="_blank"><i class="fa fa-instagram"></i></a></li>
                                         <li><a href="https://www.linkedin.com/company/hack-&-s%C3%B6hne/" target="_blank"><i class="fa fa-linkedin"></i></a></li>
                                     </ul>

--- a/src/services.html
+++ b/src/services.html
@@ -265,8 +265,6 @@
                                                 class="fa fa-twitter"></i></a></li>
                                         <li><a href="https://github.com/hackundsoehne" target="_blank"><i
                                                 class="fa fa-github"></i></a></li>
-                                        <!--<li><a href="https://slack.hackundsoehne.de/" target="_blank"><i
-                                                class="fa fa-slack"></i></a></li>-->
                                         <li><a href="https://www.instagram.com/hackundsoehne/" target="_blank"><i
                                                 class="fa fa-instagram"></i></a></li>
                                         <li><a href="https://www.linkedin.com/company/hack-&-s%C3%B6hne/"

--- a/src/soehneSuche.html
+++ b/src/soehneSuche.html
@@ -308,13 +308,6 @@
                         </li>
                         <li>
                           <a
-                            href="https://slack.hackundsoehne.de/"
-                            target="_blank"
-                            ><i class="fa fa-slack"></i
-                          ></a>
-                        </li>
-                        <li>
-                          <a
                             href="https://www.instagram.com/hackundsoehne/"
                             target="_blank"
                             ><i class="fa fa-instagram"></i

--- a/src/swift.html
+++ b/src/swift.html
@@ -185,8 +185,6 @@
                                                 class="fa fa-twitter"></i></a></li>
                                         <li><a href="https://github.com/hackundsoehne" target="_blank"><i
                                                 class="fa fa-github"></i></a></li>
-                                        <!--<li><a href="https://slack.hackundsoehne.de/" target="_blank"><i
-                                                class="fa fa-slack"></i></a></li>-->
                                         <li><a href="https://www.instagram.com/hackundsoehne/" target="_blank"><i
                                                 class="fa fa-instagram"></i></a></li>
                                         <li><a href="https://www.linkedin.com/company/hack-&-s%C3%B6hne/"

--- a/src/team.html
+++ b/src/team.html
@@ -441,7 +441,6 @@
                                                         class="fa fa-facebook"></i></a></li>
                                             <li><a href="https://twitter.com/hackundsoehne" target="_blank"><i class="fa fa-twitter"></i></a></li>
                                             <li><a href="https://github.com/hackundsoehne" target="_blank"><i class="fa fa-github"></i></a></li>
-                                            <!--<li><a href="https://slack.hackundsoehne.de/" target="_blank"><i class="fa fa-slack"></i></a></li>-->
                                             <li><a href="https://www.instagram.com/hackundsoehne/" target="_blank"><i
                                                         class="fa fa-instagram"></i></a></li>
                                             <li><a href="https://www.linkedin.com/company/hack-&-s%C3%B6hne/" target="_blank"><i

--- a/src/terms.html
+++ b/src/terms.html
@@ -216,7 +216,6 @@
                                         <li><a href="https://www.facebook.com/hackundsoehne/" target="_blank"><i class="fa fa-facebook"></i></a></li>
                                         <li><a href="https://twitter.com/hackundsoehne" target="_blank"><i class="fa fa-twitter"></i></a></li>
                                         <li><a href="https://github.com/hackundsoehne" target="_blank"><i class = "fa fa-github"></i></a></li>
-                                        <!--<li><a href="https://slack.hackundsoehne.de/" target="_blank"><i class="fa fa-slack"></i></a></li>-->
                                         <li><a href="https://www.instagram.com/hackundsoehne/" target="_blank"><i class="fa fa-instagram"></i></a></li>
                                         <li><a href="https://www.linkedin.com/company/hack-&-s%C3%B6hne/" target="_blank"><i class="fa fa-linkedin"></i></a></li>
                                     </ul>

--- a/src/util/template.html
+++ b/src/util/template.html
@@ -142,7 +142,6 @@
                                         <li><a href="https://www.facebook.com/hackundsoehne/" target="_blank"><i class="fa fa-facebook"></i></a></li>
                                         <li><a href="https://twitter.com/hackundsoehne" target="_blank"><i class="fa fa-twitter"></i></a></li>
                                         <li><a href="https://github.com/hackundsoehne" target="_blank"><i class = "fa fa-github"></i></a></li>
-                                        <!--<li><a href="https://slack.hackundsoehne.de/" target="_blank"><i class="fa fa-slack"></i></a></li>-->
                                         <li><a href="https://www.instagram.com/hackundsoehne/" target="_blank"><i class="fa fa-instagram"></i></a></li>
                                         <li><a href="https://www.linkedin.com/company-beta/11070411/2" target="_blank"><i class="fa fa-linkedin"></i></a></li>
                                     </ul>


### PR DESCRIPTION
We don't use slack.hackundsoehne.de and Smooch anymore, and the LinkedIn link was dead in some places.